### PR TITLE
feat: persistent group-shared context for DeepSeek

### DIFF
--- a/nonebot_plugin_deepseek/__init__.py
+++ b/nonebot_plugin_deepseek/__init__.py
@@ -1,9 +1,11 @@
 import itertools
 from pathlib import Path
+from typing import Optional
 from importlib import import_module
 from importlib.util import find_spec
 
 from nonebot import require
+from nonebot.adapters import Event
 from nonebot.params import Depends
 from nonebot.permission import SuperUser
 from nonebot.plugin import PluginMetadata, inherit_supported_adapters
@@ -44,6 +46,10 @@ from .version import __version__
 from .utils import DeepSeekHandler
 from .exception import RequestException
 from .extension import ParseExtension, CleanDocExtension
+from .group_context import (
+    get_group_session_id,
+    clear_context as clear_group_context,
+)
 
 __plugin_meta__ = PluginMetadata(
     name="DeepSeek",
@@ -78,6 +84,9 @@ deepseek = on_alconna(
             help_text="指定模型",
         ),
         Option("--with-context", help_text="启用多轮对话"),
+        Option("--with-group-context", help_text="启用群聊共享上下文"),
+        Option("--no-context", help_text="禁用上下文（单轮对话）"),
+        Option("--reset-group-context", help_text="重置当前群聊上下文"),
         Option("-r|--render|--render-markdown", dest="render", help_text="渲染 Markdown 为图片"),
         Option("--use-tts", help_text="使用 TTS 回复"),
         Subcommand("--balance", help_text="查看余额"),
@@ -308,12 +317,24 @@ async def _(
 
 @deepseek.handle()
 async def _(
+    event: Event,
     content: Match[tuple[str, ...]],
     model_name: Query[str] = Query("use-model.model"),
     use_tts: Query[bool] = Query("use-tts.value"),
     render_option: Query[bool] = Query("render.value"),
     context_option: Query[bool] = Query("with-context.value"),
+    with_group_context_option: Query[bool] = Query("with-group-context.value"),
+    no_context_option: Query[bool] = Query("no-context.value"),
+    reset_group_context_option: Query[bool] = Query("reset-group-context.value"),
 ) -> None:
+    if reset_group_context_option.available:
+        session_id = await get_group_session_id(event)
+        if session_id:
+            clear_group_context(session_id)
+            await deepseek.finish("已重置当前群聊上下文")
+        else:
+            await deepseek.finish("当前会话不支持群聊上下文重置")
+
     tts_model = None
     if not model_name.available:
         model_name.result = json_config.default_model
@@ -326,9 +347,24 @@ async def _(
 
     render_option.result = render_option.result if htmlrender_enable else False
 
+    # Determine whether to use group-shared context
+    is_group_context = False
+    group_session_id: Optional[str] = None
+    if not context_option.available:  # multi-round mode takes precedence
+        if no_context_option.available:
+            is_group_context = False
+        elif with_group_context_option.available:
+            group_session_id = await get_group_session_id(event)
+            is_group_context = group_session_id is not None
+        elif ds_config.enable_group_context:
+            group_session_id = await get_group_session_id(event)
+            is_group_context = group_session_id is not None
+
     await DeepSeekHandler(
         model=model,
         is_to_pic=render_option.result,
         is_contextual=context_option.available,
+        is_group_context=is_group_context,
+        group_session_id=group_session_id,
         tts_model=tts_model if use_tts.available and tts_config.enable_models else None,
     ).handle(" ".join(content.result) if content.available else None)

--- a/nonebot_plugin_deepseek/__init__.py
+++ b/nonebot_plugin_deepseek/__init__.py
@@ -48,8 +48,8 @@ from .exception import RequestException
 from .extension import ParseExtension, CleanDocExtension
 from .group_context import (
     get_group_session_id,
-    clear_context as clear_group_context,
 )
+from .group_context import clear_context as clear_group_context
 
 __plugin_meta__ = PluginMetadata(
     name="DeepSeek",

--- a/nonebot_plugin_deepseek/config.py
+++ b/nonebot_plugin_deepseek/config.py
@@ -282,6 +282,12 @@ class ScopedConfig(BaseModel):
     """Timeout"""
     stream: bool = False
     """Stream"""
+    enable_group_context: bool = False
+    """Whether to persist and share context in group chats across commands"""
+    max_group_history: int = Field(default=20, ge=1, le=100)
+    """Maximum number of messages to keep in group context"""
+    group_context_prefix: bool = True
+    """Whether to prefix user identity in group context messages"""
 
     def get_enable_models(self) -> list[str]:
         return [model.alias if model.alias else model.name for model in self.enable_models]

--- a/nonebot_plugin_deepseek/group_context.py
+++ b/nonebot_plugin_deepseek/group_context.py
@@ -1,0 +1,85 @@
+from importlib.util import find_spec
+from typing import Optional
+
+from nonebot import require
+from nonebot.adapters import Event
+from nonebot.matcher import current_bot
+
+from .config import ds_config
+
+if find_spec("nonebot_plugin_uninfo"):
+    require("nonebot_plugin_uninfo")
+    uninfo_enable = True
+else:
+    uninfo_enable = False
+
+
+# {session_id: [message, ...]}
+_group_contexts: dict[str, list[dict[str, str]]] = {}
+
+
+async def get_group_session_id(event: Event) -> Optional[str]:
+    """Return a session id for group/guild chats, or None for private chats."""
+    if uninfo_enable:
+        try:
+            from nonebot_plugin_uninfo import get_session, SceneType
+
+            session = await get_session(current_bot.get(), event)
+            if session is None:
+                return None
+            scene = session.scene
+            if scene.type == SceneType.GROUP:
+                return f"{session.scope}:group:{scene.id}"
+            if scene.type == SceneType.GUILD:
+                channel = scene.parent.id if scene.parent else scene.id
+                return f"{session.scope}:guild:{channel}"
+        except Exception:
+            pass
+
+    # Fallback for common adapters
+    message_type = getattr(event, "message_type", None)
+    if message_type == "group":
+        group_id = getattr(event, "group_id", None)
+        if group_id is not None:
+            return f"fallback:group:{group_id}"
+    return None
+
+
+async def get_user_name(event: Event) -> str:
+    user_id = event.get_user_id()
+    if uninfo_enable:
+        try:
+            from nonebot_plugin_uninfo import get_session
+
+            session = await get_session(current_bot.get(), event)
+            if session is None:
+                return user_id
+            if session.user.name:
+                return session.user.name
+            return session.user.id
+        except Exception:
+            pass
+    try:
+        sender = getattr(event, "sender", None)
+        if sender:
+            nickname = getattr(sender, "nickname", None)
+            if nickname:
+                return str(nickname)
+    except Exception:
+        pass
+    return user_id
+
+
+def get_context(session_id: str) -> list[dict[str, str]]:
+    return _group_contexts.get(session_id, [])
+
+
+def set_context(session_id: str, context: list[dict[str, str]]) -> None:
+    limit = ds_config.max_group_history
+    if len(context) > limit:
+        context = context[-limit:]
+    _group_contexts[session_id] = context
+
+
+def clear_context(session_id: str) -> None:
+    _group_contexts.pop(session_id, None)

--- a/nonebot_plugin_deepseek/group_context.py
+++ b/nonebot_plugin_deepseek/group_context.py
@@ -1,5 +1,5 @@
-from importlib.util import find_spec
 from typing import Optional
+from importlib.util import find_spec
 
 from nonebot import require
 from nonebot.adapters import Event
@@ -22,7 +22,7 @@ async def get_group_session_id(event: Event) -> Optional[str]:
     """Return a session id for group/guild chats, or None for private chats."""
     if uninfo_enable:
         try:
-            from nonebot_plugin_uninfo import get_session, SceneType
+            from nonebot_plugin_uninfo import SceneType, get_session
 
             session = await get_session(current_bot.get(), event)
             if session is None:

--- a/nonebot_plugin_deepseek/utils.py
+++ b/nonebot_plugin_deepseek/utils.py
@@ -18,7 +18,7 @@ from .schemas import Message
 from .exception import RequestException
 from .function_call.registry import registry
 from .config import CustomTTS, CustomModel, ds_config
-from .group_context import get_user_name, get_context, set_context
+from .group_context import get_context, set_context, get_user_name
 
 
 class DeepSeekHandler:

--- a/nonebot_plugin_deepseek/utils.py
+++ b/nonebot_plugin_deepseek/utils.py
@@ -18,6 +18,7 @@ from .schemas import Message
 from .exception import RequestException
 from .function_call.registry import registry
 from .config import CustomTTS, CustomModel, ds_config
+from .group_context import get_user_name, get_context, set_context
 
 
 class DeepSeekHandler:
@@ -27,17 +28,23 @@ class DeepSeekHandler:
         is_to_pic: bool,
         is_contextual: bool,
         tts_model: Optional[CustomTTS] = None,
+        is_group_context: bool = False,
+        group_session_id: Optional[str] = None,
     ) -> None:
         self.model: CustomModel = model
         self.is_to_pic: bool = is_to_pic
         self.is_contextual: bool = is_contextual
         self.tts_model: Optional[CustomTTS] = tts_model
+        self.is_group_context: bool = is_group_context
+        self.group_session_id: Optional[str] = group_session_id
         self.event: Event = current_event.get()
         self.matcher: Matcher = current_matcher.get()
         self.message_id: str = get_message_id(self.event)
         self.waiter: Waiter[Union[str, Literal[False]]] = self._setup_waiter()
 
         self.context: list[dict[str, Any]] = []
+        if self.is_group_context and self.group_session_id:
+            self.context = get_context(self.group_session_id)
 
         self.md_to_pic: Union[Callable[..., Awaitable[bytes]], None] = (
             importlib.import_module("nonebot_plugin_htmlrender").md_to_pic if self.is_to_pic else None
@@ -45,7 +52,11 @@ class DeepSeekHandler:
 
     async def handle(self, content: Optional[str]) -> None:
         if content:
-            self.context.append({"role": "user", "content": content})
+            if self.is_group_context and ds_config.group_context_prefix:
+                user_name = await get_user_name(self.event)
+                self.context.append({"role": "user", "content": f"[{user_name}] {content}"})
+            else:
+                self.context.append({"role": "user", "content": content})
 
         await self._message_reaction("thinking")
 
@@ -54,9 +65,16 @@ class DeepSeekHandler:
         else:
             await self._handle_multi_round_conversion()
 
+    def _save_group_context(self) -> None:
+        if self.is_group_context and self.group_session_id:
+            set_context(self.group_session_id, self.context)
+
     async def _handle_single_conversion(self) -> None:
         if message := await self._get_response_message():
             await self._send_response(message)
+            if self.is_group_context and self.group_session_id:
+                self.context.append(asdict(message))
+                self._save_group_context()
 
     async def _handle_multi_round_conversion(self) -> None:
         timeout = ds_config.timeout if isinstance(ds_config.timeout, int) else ds_config.timeout.user_input
@@ -72,6 +90,7 @@ class DeepSeekHandler:
 
             await self._send_response(message)
             self.context.append(asdict(message))
+            self._save_group_context()
 
             if await self._handle_tool_calls(message):
                 self.waiter.future.set_result("")


### PR DESCRIPTION
## Summary

This PR adds optional **group-shared persistent context** for the `/ds` command, so that all members in the same group can share a single DeepSeek conversation across commands, while keeping different groups isolated.

## Motivation

Currently each `/ds` invocation starts a fresh conversation. In group chats this means follow-up questions cannot reference previous messages in the same group. Multi-round mode (`--with-context`) only keeps context within one command lifecycle and is per-user.

## Changes

- Added new config options under `deepseek`:
  - `enable_group_context` (default `false`) — turn on group-shared context.
  - `max_group_history` (default `20`) — maximum messages to keep per group.
  - `group_context_prefix` (default `true`) — prefix user messages with their nickname/ID so the model knows who asked what.
- New `group_context.py` module handling:
  - Cross-adapter group/session detection via `nonebot-plugin-uninfo` when available, with a fallback to `event.message_type` / `event.group_id`.
  - In-memory per-group context store.
- Updated `DeepSeekHandler` to load existing group context at start and save updated context after each response.
- Updated command options:
  - `--with-group-context` — force group context for the current command.
  - `--no-context` — force a single-shot reply even when group context is enabled.
  - `--reset-group-context` — clear the current group's context.

## Backward Compatibility

- Group context is **disabled by default**, so existing behavior is unchanged.
- Existing single-shot, multi-round (`--with-context`), balance, model settings, TTS, Markdown-to-image and all other commands remain intact.

## Usage Example

```env
DEEPSEEK__ENABLE_GROUP_CONTEXT=true
DEEPSEEK__MAX_GROUP_HISTORY=20
```

Then in a group chat:
```
User A: /ds 介绍一下牛顿
Bot: ...
User B: /ds 他有哪些主要贡献
Bot: （会基于上一条回答继续）
User A: /ds --reset-group-context
Bot: 已重置当前群聊上下文
```

## Testing

- `ruff check nonebot_plugin_deepseek` passed.
- `pyright nonebot_plugin_deepseek` passed (only pre-existing errors in optional dependency imports remain).
- Existing pytest tests still pass.
- Manual local verification confirmed: same group shares context, different groups are isolated, history is trimmed, and reset works.