### PR TITLE
:alien: migrate deepseek models to v4 naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ plugins = ["nonebot_plugin_deepseek"]
 |              配置项              | 必填  |                             默认值                             |                                                                          说明                                                                          |
 | :------------------------------: | :---: | :------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------: |
 |        deepseek__api_key         |  是   |                               无                               |                                                                        API Key                                                                         |
-|     deepseek__enable_models      |  否   | [{ "name": "deepseek-chat" }, { "name": "deepseek-reasoner" }] | 启用的模型 [配置说明](https://github.com/KomoriDev/nonebot-plugin-deepseek/wiki/%E9%85%8D%E7%BD%AE#enable_models-%E9%85%8D%E7%BD%AE%E8%AF%B4%E6%98%8E) |
+|     deepseek__enable_models      |  否   | [{ "name": "deepseek-v4-flash" }, { "name": "deepseek-v4-pro" }] | 启用的模型 [配置说明](https://github.com/KomoriDev/nonebot-plugin-deepseek/wiki/%E9%85%8D%E7%BD%AE#enable_models-%E9%85%8D%E7%BD%AE%E8%AF%B4%E6%98%8E) |
 |         deepseek__prompt         |  否   |                               无                               |                                                                        模型预设                                                                        |
 |         deepseek__stream         |  否   |                             False                              |                                                                    是否启用流式传输                                                                    |
 |        deepseek__timeout         |  否   |             {"api_request": 100, "user_input": 60}             |                                                                        超时设定                                                                        |
@@ -167,7 +167,7 @@ deepseek --help
 ### 深度思考
 
 ```bash
-/deepseek [内容] --use-model deepseek-reasoner
+/deepseek [内容] --use-model deepseek-v4-pro
 ```
 
 快捷指令：`/深度思考 [内容]`
@@ -213,10 +213,10 @@ deepseek --help
 例子:
 
 ```bash
-user: /deepseek --shortcut /chat /deepseek --use-model deepseek-chat
+user: /deepseek --shortcut /chat /deepseek --use-model deepseek-v4-flash
 bot: deepseek::deepseek 的快捷指令: "/chat" 添加成功
 user: /chat
-bot: (使用模型 deepseek-chat)
+bot: (使用模型 deepseek-v4-flash)
 ```
 
 ## 📸 效果图

--- a/nonebot_plugin_deepseek/__init__.py
+++ b/nonebot_plugin_deepseek/__init__.py
@@ -138,7 +138,7 @@ deepseek = on_alconna(
 )
 
 deepseek.shortcut("多轮对话", {"command": "deepseek --with-context", "fuzzy": True, "prefix": True})
-deepseek.shortcut("深度思考", {"command": "deepseek --use-model deepseek-reasoner", "fuzzy": True, "prefix": True})
+deepseek.shortcut("深度思考", {"command": "deepseek --use-model deepseek-v4-pro", "fuzzy": True, "prefix": True})
 deepseek.shortcut("余额", {"command": "deepseek --balance", "fuzzy": False, "prefix": True})
 deepseek.shortcut("模型列表", {"command": "deepseek model --list", "fuzzy": False, "prefix": True})
 deepseek.shortcut("设置默认模型", {"command": "deepseek model --set-default", "fuzzy": True, "prefix": True})

--- a/nonebot_plugin_deepseek/apis/request.py
+++ b/nonebot_plugin_deepseek/apis/request.py
@@ -18,7 +18,7 @@ class API:
     }
 
     @classmethod
-    async def chat(cls, message: list[dict[str, str]], model: str = "deepseek-chat") -> ChatCompletions:
+    async def chat(cls, message: list[dict[str, str]], model: str = "deepseek-v4-flash") -> ChatCompletions:
         """普通对话"""
         model_config = ds_config.get_model_config(model)
 
@@ -39,7 +39,7 @@ class API:
         ds_logger(
             "DEBUG", f"使用模型 {f'{model} ({model_config.alias})' if model_config.alias else model}，配置：{json}"
         )
-        # if model == "deepseek-chat":
+        # if model == "deepseek-v4-flash":
         #     json.update({"tools": registry.to_json()})
         if model_dump(model_config, exclude_none=True).get("stream", ds_config.stream):
             ret = await stream_request(model_config.base_url, api_key, json, proxy)

--- a/nonebot_plugin_deepseek/config.py
+++ b/nonebot_plugin_deepseek/config.py
@@ -120,8 +120,8 @@ class CustomModel(BaseModel):
     max_tokens: int = Field(default=4090, gt=1, lt=8192)
     """
     限制一次请求中模型生成 completion 的最大 token 数
-    - `deepseek-chat`: Integer between 1 and 8192. Default is 4090.
-    - `deepseek-reasoner`: Default is 4K, maximum is 8K.
+    - `deepseek-v4-flash`: Integer between 1 and 8192. Default is 4090.
+    - `deepseek-v4-pro`: Default is 4K, maximum is 8K.
     """
     frequency_penalty: Union[int, float] = Field(default=0, ge=-2, le=2)
     """
@@ -158,7 +158,7 @@ class CustomModel(BaseModel):
             name = data.get("name")
 
             if "max_tokens" not in data:
-                if name == "deepseek-reasoner":
+                if name == "deepseek-v4-pro":
                     data["max_tokens"] = 4000
                 else:
                     data["max_tokens"] = 4090
@@ -167,7 +167,7 @@ class CustomModel(BaseModel):
             if isinstance(stop, list) and len(stop) >= 16:
                 raise ValueError("字段 `stop` 最多允许设置 16 个字符")
 
-            if name == "deepseek-chat":
+            if name == "deepseek-v4-flash":
                 temperature = data.get("temperature")
                 top_p = data.get("top_p")
                 if temperature and top_p:
@@ -178,7 +178,7 @@ class CustomModel(BaseModel):
                 if top_logprobs and logprobs is False:
                     raise ValueError("指定 `top_logprobs` 参数时，`logprobs` 必须为 True")
 
-            elif name == "deepseek-reasoner":
+            elif name == "deepseek-v4-pro":
                 max_tokens = data.get("max_tokens")
                 if max_tokens and max_tokens > 8000:
                     ds_logger("WARNING", f"模型 {name} `max_tokens` 字段最大为 8000")
@@ -268,8 +268,8 @@ class ScopedConfig(BaseModel):
     api_key: str = ""
     """Your API Key from deepseek"""
     enable_models: list[CustomModel] = [
-        CustomModel(name="deepseek-chat"),
-        CustomModel(name="deepseek-reasoner"),
+        CustomModel(name="deepseek-v4-flash"),
+        CustomModel(name="deepseek-v4-pro"),
     ]
     """List of models configurations"""
     prompt: str = ""

--- a/nonebot_plugin_deepseek/schemas/message.py
+++ b/nonebot_plugin_deepseek/schemas/message.py
@@ -39,7 +39,7 @@ class Message:
     """该 completion 的内容"""
     reasoning_content: Optional[str] = None
     """
-    仅适用于 deepseek-reasoner 模型。内容为 assistant 消息中在最终答案之前的推理内容
+    仅适用于 deepseek-v4-pro 模型。内容为 assistant 消息中在最终答案之前的推理内容
     """
     tool_calls: Optional[list[ToolCalls]] = None
     """模型生成的 tool 调用"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def pytest_configure(config: pytest.Config):
         "driver": "~fastapi",
         "log_level": "DEBUG",
         "command_start": {"/", ""},
-        "deepseek": {"api_key": "sk-xxx", "enable_models": [{"name": "deepseek-chat"}]},
+        "deepseek": {"api_key": "sk-xxx", "enable_models": [{"name": "deepseek-v4-flash"}]},
     }
 
 

--- a/tests/test_custom_model.py
+++ b/tests/test_custom_model.py
@@ -7,13 +7,13 @@ def test_custom_model():
 
     # 测试基础字段验证和默认值
     def test_default_values():
-        model = CustomModel(name="deepseek-chat")
+        model = CustomModel(name="deepseek-v4-flash")
         assert model.max_tokens == 4090
         assert model.base_url == "https://api.deepseek.com"
         assert model.temperature == 1
 
     def test_reasoner_default_max_tokens():
-        model = CustomModel(name="deepseek-reasoner")
+        model = CustomModel(name="deepseek-v4-pro")
         assert model.max_tokens == 4000
 
     def test_invalid_max_tokens_range():
@@ -44,48 +44,48 @@ def test_custom_model():
 
     # 测试模型特定逻辑
     def test_deepseek_chat_temperature_warning(caplog):
-        CustomModel(name="deepseek-chat", temperature=0.5, top_p=0.5)
+        CustomModel(name="deepseek-v4-flash", temperature=0.5, top_p=0.5)
         assert "不建议同时修改" in caplog.text
 
     def test_deepseek_reasoner_constraints():
         # 不支持 logprobs
         with pytest.raises(ValueError, match="不支持设置 logprobs"):
-            CustomModel(name="deepseek-reasoner", logprobs=True)
+            CustomModel(name="deepseek-v4-pro", logprobs=True)
 
         # 设置无效字段时抛出警告
         with pytest.warns(UserWarning, match="不支持设置") as record:
-            CustomModel(name="deepseek-reasoner", temperature=0.5, presence_penalty=1)
+            CustomModel(name="deepseek-v4-pro", temperature=0.5, presence_penalty=1)
         assert any("不支持设置" in str(warn.message) for warn in record.list)
 
     def test_top_logprobs_requires_logprobs():
         # 同时启用 logprobs 和 top_logprobs
-        CustomModel(name="deepseek-chat", logprobs=True, top_logprobs=5)
+        CustomModel(name="deepseek-v4-flash", logprobs=True, top_logprobs=5)
 
         # 仅设置 top_logprobs 不设置 logprobs
         with pytest.raises(ValueError, match="logprobs 必须为 True"):
-            CustomModel(name="deepseek-chat", top_logprobs=5)
+            CustomModel(name="deepseek-v4-flash", top_logprobs=5)
 
         # 显式关闭 logprobs 但设置 top_logprobs
         with pytest.raises(ValueError, match="logprobs 必须为 True"):
-            CustomModel(name="deepseek-chat", logprobs=False, top_logprobs=5)
+            CustomModel(name="deepseek-v4-flash", logprobs=False, top_logprobs=5)
 
     def test_logprobs_combinations(caplog):
         # 测试合法组合
-        model = CustomModel(name="deepseek-chat", logprobs=True)
+        model = CustomModel(name="deepseek-v4-flash", logprobs=True)
         assert model.logprobs is True
         assert model.top_logprobs is None
 
         # 测试带 top_logprobs 的合法组合
-        model = CustomModel(name="deepseek-chat", logprobs=True, top_logprobs=10)
+        model = CustomModel(name="deepseek-v4-flash", logprobs=True, top_logprobs=10)
         assert model.top_logprobs == 10
 
         # 测试非法组合的异常消息
         with pytest.raises(ValueError, match="logprobs 必须为 True") as excinfo:
-            CustomModel(name="deepseek-chat", top_logprobs=5)
+            CustomModel(name="deepseek-v4-flash", top_logprobs=5)
         assert "logprobs 必须为 True" in str(excinfo.value)
 
         def test_reasoner_max_tokens_warning(caplog):
-            CustomModel(name="deepseek-reasoner", max_tokens=8001)
+            CustomModel(name="deepseek-v4-pro", max_tokens=8001)
             assert "最大为 8000" in caplog.text
 
     # 测试额外字段和配置


### PR DESCRIPTION
## 变更说明

将弃用的模型名称迁移到新的 v4 命名规范：

- deepseek-chat → deepseek-v4-flash
- deepseek-reasoner → deepseek-v4-pro

## 弃用时间

2026/07/24

## 修改范围

- 核心代码：更新默认模型参数、API 请求处理、配置验证逻辑
- 文档：更新 README 示例和模型配置说明
- 测试：更新测试用例和测试配置